### PR TITLE
Issue with Task execution order fixed (File name related)

### DIFF
--- a/WinPEImager/Classes/CMDR.cs
+++ b/WinPEImager/Classes/CMDR.cs
@@ -33,6 +33,16 @@ namespace WinPEImager.Classes
             process.StartInfo.RedirectStandardInput = true;
             process.StartInfo.RedirectStandardError = true;
 
+            process.EnableRaisingEvents = true;
+            process.Exited += (sender, e) => {
+
+                process.CancelErrorRead();
+                process.CancelOutputRead();
+                
+                process.StandardInput.Flush();
+            
+            };
+
 
             process.ErrorDataReceived += (s, e) =>
             {
@@ -149,11 +159,10 @@ namespace WinPEImager.Classes
             process.CancelOutputRead();
 
 
-
-
             if (values.Count() != 0)
             {
                 Console.WriteLine("ERRORS: " + values.Count());
+
                 return false;
             }
             else
@@ -162,11 +171,11 @@ namespace WinPEImager.Classes
                 return true;
             }
 
-
         }
 
         public void StandaloneCMD()
         {
+
 
             Process proc = new Process();
             proc.StartInfo.FileName = "cmd.exe";

--- a/WinPEImager/Classes/CMDR.cs
+++ b/WinPEImager/Classes/CMDR.cs
@@ -140,7 +140,7 @@ namespace WinPEImager.Classes
                 //process.StartInfo.WorkingDirectory = Config.Instance().GetWorkingDir() + @"\Required\";
                 //process.StartInfo.Arguments =  task.command;
                 //Console.WriteLine(process.StartInfo.WorkingDirectory);
-                process.StartInfo.Arguments = "/C " + Config.Instance().GetWorkingDir() + @"\Required\" + task.command;
+                process.StartInfo.Arguments = "/C " + "\"" + Config.Instance().GetWorkingDir() + @"\Required\" + task.command + "\"";
 
 
 

--- a/WinPEImager/Classes/Image.cs
+++ b/WinPEImager/Classes/Image.cs
@@ -65,16 +65,30 @@ namespace WinPEImager.Classes
 
             CopyDirectory(path + @"\Required\", Config.Instance().GetWorkingDir() + @"\Required\", true);
 
+            //TODO: I think the tasks start at the same time, therefore the same batch file can run at the same time, if it's too fast.
+            //IE. test 1 starts, then test 2 but test 2 actually still uses old batch file for test 1 from memory.
+            //TODO: add a check to make sure the task is one before continuting
             foreach (Task task in taskList)
             {
                 if (canStart == true)
                 {
                     CMDR.GetProcess().WriteToConsole("========== RUNNING TASK: " + task.command + " ==========");
                     //Call execute the task
-                    await task.Execute();
+                   bool isDone = await task.Execute();
+
+
+                    while (!isDone)
+                    {
+                        break;
+                    }
                     CMDR.GetProcess().WriteToConsole("========== TASK " + task.GetStatus() + " ==========");
                     //change the image indes of the task in the list view
                     listview.Invoke(new MethodInvoker(delegate { listview.FindItemWithText(task.command).ImageIndex = ((int)task.GetStatus()); }));
+
+
+
+
+
                 }
             }
             started = false;

--- a/WinPEImager/Classes/Image.cs
+++ b/WinPEImager/Classes/Image.cs
@@ -58,7 +58,7 @@ namespace WinPEImager.Classes
         }
 
         //Start executing the tasks
-        public async void Start()
+        public async Task<bool> Start()
         {
             //temporary list, in case list manipulation will need to happen in the future (proper queue system)
             List<Task> taskList = tasks;
@@ -67,30 +67,34 @@ namespace WinPEImager.Classes
 
             //TODO: I think the tasks start at the same time, therefore the same batch file can run at the same time, if it's too fast.
             //IE. test 1 starts, then test 2 but test 2 actually still uses old batch file for test 1 from memory.
-            //TODO: add a check to make sure the task is one before continuting
+            //TODO: add a check to make sure the task is done before continuting
             foreach (Task task in taskList)
             {
+
                 if (canStart == true)
                 {
                     CMDR.GetProcess().WriteToConsole("========== RUNNING TASK: " + task.command + " ==========");
                     //Call execute the task
-                   bool isDone = await task.Execute();
-
-
-                    while (!isDone)
-                    {
-                        break;
-                    }
+                    var isDone = await task.Execute();
                     CMDR.GetProcess().WriteToConsole("========== TASK " + task.GetStatus() + " ==========");
-                    //change the image indes of the task in the list view
                     listview.Invoke(new MethodInvoker(delegate { listview.FindItemWithText(task.command).ImageIndex = ((int)task.GetStatus()); }));
 
+                    if (isDone)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
 
-
-
-
+                    //change the image indes of the task in the list view
+                }
+                else {
+                    return false;
                 }
             }
+            return false;
             started = false;
         }
 

--- a/WinPEImager/Classes/Task.cs
+++ b/WinPEImager/Classes/Task.cs
@@ -107,7 +107,7 @@ namespace WinPEImager.Classes
 
                         this.currentStatus = STATUS.Processing;
                         parentImage.ToList();
-                        sucessful = await AsyncTask.Run(() => CMDR.GetProcess().RunCommand(this));
+                        sucessful = await CMDR.GetProcess().RunCommand(this);
 
                         if (!sucessful)
                         {

--- a/WinPEImager/Classes/Task.cs
+++ b/WinPEImager/Classes/Task.cs
@@ -8,6 +8,7 @@ using WinPEImager.Classes;
 
 using AsyncTask = System.Threading.Tasks.Task;
 using WinPEImager.Classes.Enums;
+using System.Threading.Tasks;
 
 namespace WinPEImager.Classes
 {
@@ -93,7 +94,7 @@ namespace WinPEImager.Classes
             return this;
         }
 
-        public async AsyncTask Execute()
+        public async Task<bool> Execute()
         {
             
             try
@@ -126,6 +127,7 @@ namespace WinPEImager.Classes
                     else
                     {
                         MessageBox.Show("Task: " + this.command + " Has already been executed");
+                        return false;
                     }
                 }
                 else
@@ -134,12 +136,14 @@ namespace WinPEImager.Classes
                     this.currentStatus = STATUS.Sucessful;
                     parentImage.ToList();
                 }
+                return true;
             }
             catch (Exception e)
             {
                 //Console.WriteLine("Exception: "+e);
                 this.currentStatus = STATUS.Failed;
                 parentImage.ToList();
+                return true;
             }
         }
     }

--- a/WinPEImager/Form1.Designer.cs
+++ b/WinPEImager/Form1.Designer.cs
@@ -47,9 +47,11 @@
             this.centerPanel = new System.Windows.Forms.Panel();
             this.treeView = new System.Windows.Forms.Panel();
             this.taskControl = new System.Windows.Forms.Panel();
+            this.refreshBtn = new System.Windows.Forms.Button();
             this.rightPanel = new System.Windows.Forms.Panel();
             this.listPanel = new System.Windows.Forms.Panel();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.taskSelectionLabel = new System.Windows.Forms.Label();
             this.tasksLabel = new System.Windows.Forms.Label();
             this.mainPanel = new System.Windows.Forms.Panel();
             this.masterPathLabel = new System.Windows.Forms.Label();
@@ -76,8 +78,6 @@
             this.searchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.aboutToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.taskSelectionLabel = new System.Windows.Forms.Label();
-            this.refreshBtn = new System.Windows.Forms.Button();
             this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -86,6 +86,7 @@
             this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.notepadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.leftPanel.SuspendLayout();
             this.consolePanel.SuspendLayout();
             this.consoleInputPanel.SuspendLayout();
@@ -300,6 +301,21 @@
             this.taskControl.Size = new System.Drawing.Size(277, 30);
             this.taskControl.TabIndex = 10;
             // 
+            // refreshBtn
+            // 
+            this.refreshBtn.BackColor = System.Drawing.Color.White;
+            this.refreshBtn.BackgroundImage = global::WinPEImager.Properties.Resources.refresh_30x30;
+            this.refreshBtn.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.refreshBtn.Dock = System.Windows.Forms.DockStyle.Left;
+            this.refreshBtn.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.refreshBtn.Location = new System.Drawing.Point(0, 0);
+            this.refreshBtn.Name = "refreshBtn";
+            this.refreshBtn.Size = new System.Drawing.Size(30, 30);
+            this.refreshBtn.TabIndex = 5;
+            this.toolTip1.SetToolTip(this.refreshBtn, "Refresh and rediscover Autmation Scripts in master directory.");
+            this.refreshBtn.UseVisualStyleBackColor = false;
+            this.refreshBtn.Click += new System.EventHandler(this.refreshBtn_Click);
+            // 
             // rightPanel
             // 
             this.rightPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -331,6 +347,18 @@
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(274, 49);
             this.panel1.TabIndex = 9;
+            // 
+            // taskSelectionLabel
+            // 
+            this.taskSelectionLabel.AutoSize = true;
+            this.taskSelectionLabel.BackColor = System.Drawing.Color.Gainsboro;
+            this.taskSelectionLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.taskSelectionLabel.Location = new System.Drawing.Point(4, 3);
+            this.taskSelectionLabel.Name = "taskSelectionLabel";
+            this.taskSelectionLabel.Size = new System.Drawing.Size(93, 13);
+            this.taskSelectionLabel.TabIndex = 0;
+            this.taskSelectionLabel.Text = "No Selected Task";
+            this.toolTip1.SetToolTip(this.taskSelectionLabel, "Currently selected Automation Script Task");
             // 
             // tasksLabel
             // 
@@ -392,7 +420,8 @@
             // toolsToolStripMenuItem
             // 
             this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.consoleToolStripMenuItem});
+            this.consoleToolStripMenuItem,
+            this.notepadToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
             this.toolsToolStripMenuItem.Text = "Tools";
@@ -400,7 +429,7 @@
             // consoleToolStripMenuItem
             // 
             this.consoleToolStripMenuItem.Name = "consoleToolStripMenuItem";
-            this.consoleToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.consoleToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.consoleToolStripMenuItem.Text = "Console";
             this.consoleToolStripMenuItem.Click += new System.EventHandler(this.consoleToolStripMenuItem_Click);
             // 
@@ -509,33 +538,6 @@
             this.aboutToolStripMenuItem1.Size = new System.Drawing.Size(32, 19);
             this.aboutToolStripMenuItem1.Text = "&About...";
             // 
-            // taskSelectionLabel
-            // 
-            this.taskSelectionLabel.AutoSize = true;
-            this.taskSelectionLabel.BackColor = System.Drawing.Color.Gainsboro;
-            this.taskSelectionLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.taskSelectionLabel.Location = new System.Drawing.Point(4, 3);
-            this.taskSelectionLabel.Name = "taskSelectionLabel";
-            this.taskSelectionLabel.Size = new System.Drawing.Size(93, 13);
-            this.taskSelectionLabel.TabIndex = 0;
-            this.taskSelectionLabel.Text = "No Selected Task";
-            this.toolTip1.SetToolTip(this.taskSelectionLabel, "Currently selected Automation Script Task");
-            // 
-            // refreshBtn
-            // 
-            this.refreshBtn.BackColor = System.Drawing.Color.White;
-            this.refreshBtn.BackgroundImage = global::WinPEImager.Properties.Resources.refresh_30x30;
-            this.refreshBtn.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.refreshBtn.Dock = System.Windows.Forms.DockStyle.Left;
-            this.refreshBtn.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.refreshBtn.Location = new System.Drawing.Point(0, 0);
-            this.refreshBtn.Name = "refreshBtn";
-            this.refreshBtn.Size = new System.Drawing.Size(30, 30);
-            this.refreshBtn.TabIndex = 5;
-            this.toolTip1.SetToolTip(this.refreshBtn, "Refresh and rediscover Autmation Scripts in master directory.");
-            this.refreshBtn.UseVisualStyleBackColor = false;
-            this.refreshBtn.Click += new System.EventHandler(this.refreshBtn_Click);
-            // 
             // newToolStripMenuItem
             // 
             this.newToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("newToolStripMenuItem.Image")));
@@ -606,6 +608,13 @@
             this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
             this.pasteToolStripMenuItem.Size = new System.Drawing.Size(32, 19);
             this.pasteToolStripMenuItem.Text = "&Paste";
+            // 
+            // notepadToolStripMenuItem
+            // 
+            this.notepadToolStripMenuItem.Name = "notepadToolStripMenuItem";
+            this.notepadToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.notepadToolStripMenuItem.Text = "Notepad";
+            this.notepadToolStripMenuItem.Click += new System.EventHandler(this.notepadToolStripMenuItem_Click);
             // 
             // Form1
             // 
@@ -705,6 +714,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem1;
         private System.Windows.Forms.Label taskSelectionLabel;
+        private System.Windows.Forms.ToolStripMenuItem notepadToolStripMenuItem;
     }
 
     

--- a/WinPEImager/Form1.cs
+++ b/WinPEImager/Form1.cs
@@ -237,7 +237,7 @@ namespace WinPEImager
             }
         }
 
-        private void startButton_Click(object sender, EventArgs e)
+        private async void startButton_Click(object sender, EventArgs e)
         {
             if (currentSelectedImage != null)
             {
@@ -245,7 +245,7 @@ namespace WinPEImager
                 {
                     
                     currentSelectedImage.canStart = true;
-                    currentSelectedImage.Start();
+                    await currentSelectedImage.Start();
                     startButton.Text = "STOP";
 
                 }

--- a/WinPEImager/Form1.cs
+++ b/WinPEImager/Form1.cs
@@ -375,5 +375,14 @@ namespace WinPEImager
                 selectedTask.task.GetParentImage().StartOne(selectedTask.task);
             }
         }
+
+        private void notepadToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+
+            Process proc = new Process();
+            proc.StartInfo.FileName = "notepad.exe";
+            proc.StartInfo.UseShellExecute = false;
+            proc.Start();
+        }
     }
 }

--- a/WinPEImager/Form1.resx
+++ b/WinPEImager/Form1.resx
@@ -123,9 +123,6 @@
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>125, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="newToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
After extensive testing, the issue was not the Task execution order but rather passing a batch file which name contains a space. The issue occurred when running an Automation Script which contained similarly named batch scripts. In this case first batch file was called "test.bat" but the next one was "test test.bat". When "test test.bat" was passed to CMDR as a process argument, the process located a "test" batch file instead of the intended "test test.bat" file. Added some escaped quotes to the process argument to prevent this issue in the future.